### PR TITLE
add bucket support config.toml

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -5,5 +5,6 @@ title = "configuration of rsync-os"
   endpoint = "127.0.0.1:9000"
   keyAccess = "minioadmin"
   keySecret = "minioadmin"
+  bucket = "mirrorsync"
   [minio.boltdb]
     path = "test.db"


### PR DESCRIPTION
minio server only support bucket with Lowercase letters, period, hyphen, numerals are the only allowed characters and should be minimum 3 characters in length. so if we want to mirror perl like CPAN/ , it will error.  change the bucket name to key can solve it .